### PR TITLE
Make text more readable base font 13px > 13pt

### DIFF
--- a/pybossa/static/css/styles.css
+++ b/pybossa/static/css/styles.css
@@ -391,7 +391,7 @@ body {
   padding-top: 105px;
   /* Allow for Header */
 
-  font-size: 13px;
+  font-size: 13pt;
 }
 
 


### PR DESCRIPTION
13px is possibly a typo--need a magnifying glass to read this text. 

Alternatively just up the font size in p